### PR TITLE
Fixes btuart setting right bt address on arm64 kernels.

### DIFF
--- a/usr/bin/btuart
+++ b/usr/bin/btuart
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 HCIATTACH=/usr/bin/hciattach
-SERIAL=`grep Serial /proc/cpuinfo | cut -c19-`
+SERIAL=`cat /proc/device-tree/serial-number | cut -c9-`
 B1=`echo $SERIAL | cut -c3-4`
 B2=`echo $SERIAL | cut -c5-6`
 B3=`echo $SERIAL | cut -c7-8`


### PR DESCRIPTION
Serial # is not in /proc/cpuinfo on arm64 kernels, so we pull it from the device tree.