### PR TITLE
Improved hciuart service condition

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pi-bluetooth (0.1.10) stretch; urgency=medium
+
+  * Improved hciuart service condition
+
+ -- Serge Schneider <serge@raspberrypi.org>  Mon, 29 Oct 2018 12:02:55 +0000
+
 pi-bluetooth (0.1.9) stretch; urgency=medium
 
   * Do not wait for hciuart before staring bluetoothd

--- a/debian/pi-bluetooth.hciuart.service
+++ b/debian/pi-bluetooth.hciuart.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Configure Bluetooth Modems connected by UART
-ConditionPathIsDirectory=/proc/device-tree/soc/gpio@7e200000/bt_pins
+ConditionFileNotEmpty=/proc/device-tree/soc/gpio@7e200000/bt_pins/brcm,pins
 Requires=dev-serial1.device
 After=dev-serial1.device
 


### PR DESCRIPTION
The pi3-disable-bt overlay doesn't (and can't) delete the bt_pins node,
but the latest version of the overlay makes its properties (including
`brcm,pins`) zero length. Take advantage of this change by making the
hciuart execution condition:
```
ConditionFileNotEmpty=/proc/device-tree/soc/gpio@7e200000/bt_pins/brcm,pins
```