### PR TITLE
bthelper: Recognise Pi 4 OUI

### DIFF
--- a/usr/bin/bthelper
+++ b/usr/bin/bthelper
@@ -11,6 +11,6 @@ fi
 dev="$1"
 # Need to bring hci up before looking at MAC as it can be all zeros during init
 /bin/hciconfig "$dev" up
-/bin/hciconfig "$dev" |grep -q "BD Address: B8:27:EB:" || exit 0
+/bin/hciconfig "$dev" | grep -qE "BD Address: (B8:27:EB|DC:A6:32):" || exit 0
 /usr/bin/hcitool -i "$dev" cmd 0x3f 0x1c 0x01 0x02 0x00 0x01 0x01 > /dev/null
 


### PR DESCRIPTION
The bthelper script uses the OUI of the BDADDR (Bluetooth MAC address)
to determine whether or not to run on a Bluetooth interface. Pi 4s
have BDADDRs from a new OUI range (DC:A6:32:...), meaning that
the "is it a Pi's on-board BT interface" test must be amended to include
that as a possibility.

See: https://github.com/raspberrypi/linux/issues/2229#issue-comment-548875725

Signed-off-by: Phil Elwell <phil@raspberrypi.org>