### PR TITLE
bthelper: Force reinitialisation to allow Secure Simple Pairing

### DIFF
--- a/usr/bin/bthelper
+++ b/usr/bin/bthelper
@@ -8,6 +8,11 @@ if [ "$#" -ne 1 ]; then
    exit 0
 fi
 
+# Force reinitialisation to allow extra features such as Secure Simple Pairing
+# to be enabled
+/usr/bin/bluetoothctl power off
+/usr/bin/bluetoothctl power on
+
 dev="$1"
 # Need to bring hci up before looking at MAC as it can be all zeros during init
 /bin/hciconfig "$dev" up


### PR DESCRIPTION
Using bluetoothctl to toggle "power" off and on again is enough
to cause optional local features such as Secure Simple Pairing
to be enabled.

Note that this is required to support a Microsoft Designer Mouse,
and possibly others.

Signed-off-by: Phil Elwell <phil@raspberrypi.com>