### PR TITLE
btuart: Allow BDADDR to be supplied by service

### DIFF
--- a/debian/pi-bluetooth.hciuart.service
+++ b/debian/pi-bluetooth.hciuart.service
@@ -6,6 +6,7 @@ After=dev-serial1.device
 
 [Service]
 Type=forking
+EnvironmentFile=-/etc/default/hciuart
 ExecStart=/usr/bin/btuart
 
 [Install]

--- a/usr/bin/btuart
+++ b/usr/bin/btuart
@@ -1,7 +1,13 @@
 #!/bin/sh
 
 HCIATTACH=/usr/bin/hciattach
-if grep -q "Pi 4" /proc/device-tree/model; then
+if [ -n "$BDADDR" ]; then
+  # Allow environment override of BDADDR via the init service.
+  # Shouldn't be needed in normal cases; exceptions include Raspberry
+  # Pi 4 systems with bluez which don't have raspberry-pi-mods.patch
+  # applied.
+  true
+elif grep -q "Pi 4" /proc/device-tree/model; then
   BDADDR=
 else
   SERIAL=`cat /proc/device-tree/serial-number | cut -c9-`


### PR DESCRIPTION
For systems where the rpt-patched bluez package is not installed and
cannot automatically determine the address.