### PR TITLE
Widen match for CM4 compatibility

### DIFF
--- a/usr/bin/btuart
+++ b/usr/bin/btuart
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 HCIATTACH=/usr/bin/hciattach
-if grep -q "Pi 4" /proc/device-tree/model; then
+if grep -q "raspberrypi,4" /proc/device-tree/compatible; then
   BDADDR=
 else
   SERIAL=`cat /proc/device-tree/serial-number | cut -c9-`


### PR DESCRIPTION
The existing test tries to find "Pi 4" in the d-t model string. This works fine for the Model 4B ("Raspberry Pi 4 Model B Rev 1.x"), and the 400 ("Raspberry Pi 400 Rev 1.0"). However, it doesn't match the model string on the Compute Module 4 ("Raspberry Pi Compute Module 4 Rev 1.0").

This commit uses the d-t compatible string instead and matches on "raspberrypi,4" which matches the Pi 4 and 400 (which both have "raspberrypi,4-model-b" in their compatible value) and the CM4 (which has "raspberrypi,4-compute-module").

Instead of matching a sub-string it *might* be preferable to match the "brcm,bcm2711" element (which again covers all the necessary platforms), but that might be considered too "wide" a match (if there's anything else using a BCM2711)?