### PR TITLE
Multiple fixes

### DIFF
--- a/debian/pi-bluetooth.bthelper@.service
+++ b/debian/pi-bluetooth.bthelper@.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Raspberry Pi bluetooth helper
-Requires=bluetooth.service
-After=bluetooth.service
+Requires=hciuart.service
+After=hciuart.service
+Before=bluetooth.service
 
 [Service]
 Type=oneshot

--- a/debian/pi-bluetooth.hciuart.service
+++ b/debian/pi-bluetooth.hciuart.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Configure Bluetooth Modems connected by UART
 ConditionFileNotEmpty=/proc/device-tree/soc/gpio@7e200000/bt_pins/brcm,pins
-Requires=dev-serial1.device
 After=dev-serial1.device
+Before=bluetooth.device
 
 [Service]
 Type=forking

--- a/usr/bin/bthelper
+++ b/usr/bin/bthelper
@@ -31,10 +31,11 @@ else
     echo Raspberry Pi BDADDR already set
 fi
 
-# Force reinitialisation to allow extra features such as Secure Simple Pairing
-# to be enabled
-/usr/bin/bluetoothctl power off
-/usr/bin/bluetoothctl power on
-
 # Route SCO packets to the HCI interface (enables HFP/HSP)
 /usr/bin/hcitool -i $dev cmd 0x3f 0x1c 0x01 0x02 0x00 0x01 0x01 > /dev/null
+
+# Force reinitialisation to allow extra features such as Secure Simple Pairing
+# to be enabled, for currently unknown reasons. This requires bluetoothd to be
+# running, which it isn't yet. Use this kludge of forking off another shell
+# with a delay, pending a complete understanding of the issues.
+(sleep 5; /usr/bin/bluetoothctl power off; /usr/bin/bluetoothctl power on) &

--- a/usr/bin/btuart
+++ b/usr/bin/btuart
@@ -11,7 +11,8 @@ else
   BDADDR=`printf b8:27:eb:%02x:%02x:%02x $((0x$B1 ^ 0xaa)) $((0x$B2 ^ 0xaa)) $((0x$B3 ^ 0xaa))`
 fi
 
-if ( /usr/bin/hcitool dev | grep -q -E '\s(B8:27:EB:|DC:A6:32:)' ); then
+# Bail out if the kernel is managing the Bluetooth modem initialisation
+if ( dmesg | grep -q -E "hci[0-9]+: BCM: chip" ); then
   # On-board bluetooth is already enabled
   exit 0
 fi


### PR DESCRIPTION
Rationalise the Bluetooth helper services so that they run before
bluetoothd, avoiding the need to restart it if the BT address changes.
At a later date the two services could possibly be unified.

These scripts should be revisited when the reason for the need to
power-cycle the interface to permit Secure Simple Pairing work is known.

Signed-off-by: Phil Elwell <phil@raspberrypi.com>