### PR TITLE
fix service units, bluetooth.service not starting successfully

### DIFF
--- a/debian/pi-bluetooth.bthelper@.service
+++ b/debian/pi-bluetooth.bthelper@.service
@@ -2,7 +2,7 @@
 Description=Raspberry Pi bluetooth helper
 Requires=hciuart.service
 After=hciuart.service
-Before=bluetooth.service
+After=bluetooth.service
 
 [Service]
 Type=oneshot

--- a/debian/pi-bluetooth.hciuart.service
+++ b/debian/pi-bluetooth.hciuart.service
@@ -2,7 +2,7 @@
 Description=Configure Bluetooth Modems connected by UART
 ConditionFileNotEmpty=/proc/device-tree/soc/gpio@7e200000/bt_pins/brcm,pins
 After=dev-serial1.device
-Before=bluetooth.device
+Before=bluetooth.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Some of the changes in #21 made bluetooth.service stop working on my RPi 4. Only with the changes in this PR it began starting reliably again after rebooting.

I am no bluetooth guru and just debugged the problem using the info systemd and the service units gave me; please consider that when reviewing the changes. :smile: 