### PR TITLE
Another systemd service adjustment

### DIFF
--- a/debian/pi-bluetooth.bthelper@.service
+++ b/debian/pi-bluetooth.bthelper@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Raspberry Pi bluetooth helper
-Requires=hciuart.service
+Requires=hciuart.service bluetooth.service
 After=hciuart.service
 Before=bluetooth.service
 

--- a/debian/pi-bluetooth.hciuart.service
+++ b/debian/pi-bluetooth.hciuart.service
@@ -2,7 +2,6 @@
 Description=Configure Bluetooth Modems connected by UART
 ConditionFileNotEmpty=/proc/device-tree/soc/gpio@7e200000/bt_pins/brcm,pins
 After=dev-serial1.device
-Before=bluetooth.device
 
 [Service]
 Type=forking


### PR DESCRIPTION
The previous commit included an invalid reference to bluetooth.device,
which doesn't exist. Fix that, and give bthelper@.service a strict
dependency on bluetooth.service.

See: https://github.com/RPi-Distro/pi-bluetooth/pull/22

Signed-off-by: Phil Elwell <phil@raspberrypi.com>