### PR TITLE
Add a btserial command and move serial device rules

### DIFF
--- a/lib/udev/rules.d/90-pi-bluetooth.rules
+++ b/lib/udev/rules.d/90-pi-bluetooth.rules
@@ -1,2 +1,8 @@
+# Create /dev/serialN symlinks (required by the bluetooth modem firmware). The
+# logic below deals with the different serial UARTs on different models of Pi
+# and ensures that /dev/serial1 (which hciuart.service relies upon) points to
+# the correct UART device
+KERNEL=="ttyAMA0|ttyAMA1|ttyS0", PROGRAM="/usr/bin/btserial %k", SYMLINK+="serial%c"
+
 # Raspberry Pi bluetooth module: enable routing of SCO packets to the HCI interface
 ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci[0-9]", TAG+="systemd", ENV{SYSTEMD_WANTS}+="bthelper@%k.service"

--- a/usr/bin/btserial
+++ b/usr/bin/btserial
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+ALIASES=/proc/device-tree/aliases
+
+case "$1" in
+    ttyAMA0)
+        UART=uart0
+        ;;
+    ttyAMA1)
+        if [ -e /dev/ttyAMA0 ]; then
+            exit 1
+        fi
+        UART=uart0
+        ;;
+    ttyS0)
+        UART=uart1
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+
+if cmp -s "$ALIASES"/"$UART" "$ALIASES"/serial0; then
+    echo 0
+elif cmp -s "$ALIASES"/"$UART" "$ALIASES"/serial1; then
+    echo 1
+else
+    exit 1
+fi


### PR DESCRIPTION
I'm not sure if this will be of interest, but just in case:

In RaspiOS, the udev rules for configuring the `/dev/serialN` devices exist in `/etc/udev/rules.d/99-com.rules` and involve a few chunks of shell-script for determining which UART to point the serialN alias(es) at.

With the version of udev in Bullseye (and coincidentally, Ubuntu Hirsute onwards), udev complains about the `$ALIASES` substitution in this rule. In Bullseye, this was fixed by [escaping it to `$$ALIASES`](https://github.com/RPi-Distro/raspberrypi-sys-mods/commit/c213dc634fe74d98eacef2ca8a9d7f8c51526236), but I thought it might be a little cleaner to spin this logic out into its own script, and stuff all the rules and logic in the `pi-bluetooth` package (this is what I'm doing in the Ubuntu version of the package).

Incidentally, if you do decide to merge this, you would need to remove the [corresponding chunk in RPi-Distro/raspberrypi-sys-mods](https://github.com/RPi-Distro/raspberrypi-sys-mods/blob/22af5d1c65f3ac8c6f0ba4bdb8bdaf4184b73464/etc.arm/udev/rules.d/99-com.rules#L17-L50).

Closes #27 (which should probably be closed anyway as RaspiOS Bullseye already fixed this)